### PR TITLE
Fix README environment command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ git clone https://github.com/PabloMendieta03/TSP_Classical_Solutions.git
 Creación del entorno: 
 ```
  Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
- ptyhon -m venv tsp-venv 
+ python -m venv tsp-venv 
  .\tsp-venv\Scripts\Activate
 ```
 Instalación de dependencias: 


### PR DESCRIPTION
## Summary
- correct typo in README setup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f40d91da08320b3e8db3a723cc40d